### PR TITLE
Raise test coverage

### DIFF
--- a/PInvoke.Core/NativeTypes.cs
+++ b/PInvoke.Core/NativeTypes.cs
@@ -554,7 +554,7 @@ namespace PInvoke
         public NativeEnumValue(string name, string value)
         {
             this.Name = name;
-            _value = new NativeValueExpression(value);
+            Value = new NativeValueExpression(value);
         }
 
         public override NativeSymbolKind Kind
@@ -924,7 +924,7 @@ namespace PInvoke
 
         public NativeNamedType(string qualification, string name) : base(name)
         {
-            _qualification = qualification;
+            Qualification = qualification;
         }
 
         public NativeNamedType(string name) : base(name)
@@ -938,7 +938,7 @@ namespace PInvoke
 
         public NativeNamedType(string qualification, string name, bool isConst) : base(name)
         {
-            _qualification = qualification;
+            Qualification = qualification;
             _isConst = isConst;
         }
 
@@ -1161,7 +1161,7 @@ namespace PInvoke
 
         public NativeBuiltinType(BuiltinType bt) : base("")
         {
-            _builtinType = bt;
+            BuiltinType = bt;
             Init();
         }
 
@@ -1173,7 +1173,7 @@ namespace PInvoke
 
         public NativeBuiltinType(string name) : base(name)
         {
-            _builtinType = PInvoke.BuiltinType.NativeUnknown;
+            BuiltinType = PInvoke.BuiltinType.NativeUnknown;
             Init();
         }
 
@@ -1772,7 +1772,7 @@ namespace PInvoke
             }
 
             this.Name = name;
-            _constantKind = kind;
+            ConstantKind = kind;
 
             // We don't support macro methods at this point.  Instead we will just generate out the 
             // method signature for the method and print the string out into the code
@@ -1781,7 +1781,7 @@ namespace PInvoke
                 value = "\"" + value + "\"";
             }
 
-            _value = new NativeValueExpression(value);
+            Value = new NativeValueExpression(value);
         }
 
         public override System.Collections.Generic.IEnumerable<NativeSymbol> GetChildren()

--- a/PInvoke.Core/Parser/ExpressionNode.cs
+++ b/PInvoke.Core/Parser/ExpressionNode.cs
@@ -74,7 +74,7 @@ namespace PInvoke.Parser
         public ExpressionNode(ExpressionKind kind, Token value)
         {
             _kind = kind;
-            _token = value;
+            Token = value;
         }
 
         public static ExpressionNode CreateLeaf(bool bValue)

--- a/PInvoke.Core/Parser/Macro.cs
+++ b/PInvoke.Core/Parser/Macro.cs
@@ -88,7 +88,7 @@ namespace PInvoke.Parser
 
         public Macro(string name)
         {
-            _name = name;
+            Name = name;
         }
 
         public Macro(string name, string val) : this(name, val, false)
@@ -97,9 +97,9 @@ namespace PInvoke.Parser
 
         public Macro(string name, string val, bool permanent)
         {
-            _name = name;
-            _value = val;
-            _isPermanent = permanent;
+            Name = name;
+            Value = val;
+            IsPermanent = permanent;
         }
 
     }

--- a/PInvoke.Core/Transform/BasicConverter.cs
+++ b/PInvoke.Core/Transform/BasicConverter.cs
@@ -69,8 +69,8 @@ namespace PInvoke.Transform
 
         public BasicConverter(LanguageType type, NativeStorage ns)
         {
-            _ns = ns;
-            _type = type;
+            NativeStorage = ns;
+            LanguageType = type;
         }
 
         public CodeTypeDeclarationCollection ConvertToCodeDom(NativeConstant c, ErrorProvider ep)

--- a/PInvoke.Core/Transform/BasicConverter.cs
+++ b/PInvoke.Core/Transform/BasicConverter.cs
@@ -186,7 +186,7 @@ namespace PInvoke.Transform
                 NativeCodeAnalyzerResult result = analyzer.Analyze(reader);
 
                 ep.Append(result.ErrorProvider);
-                bag = NativeSymbolBag.CreateFrom(result, _ns);
+                bag = NativeSymbolBag.CreateFrom(result, NativeStorage);
             }
 
             return ConvertBagToCodeDom(bag, ep);
@@ -292,8 +292,8 @@ namespace PInvoke.Transform
             bag.TryResolveSymbolsAndValues(ep);
 
             // Create the codedom transform
-            CodeTransform transform = new CodeTransform(this._type, bag);
-            MarshalTransform marshalUtil = new MarshalTransform(this._type, bag, _transformKind);
+            CodeTransform transform = new CodeTransform(LanguageType, bag);
+            MarshalTransform marshalUtil = new MarshalTransform(LanguageType, bag, TransformKindFlags);
             CodeTypeDeclarationCollection col = new CodeTypeDeclarationCollection();
 
             // Only output the constants if there are actually any

--- a/PInvoke.Core/Transform/CustomCodeDom.cs
+++ b/PInvoke.Core/Transform/CustomCodeDom.cs
@@ -105,7 +105,7 @@ namespace PInvoke.Transform
 
             using (var writer = new StringWriter())
             {
-                provider.GenerateCodeFromExpression(_expr, writer, new CodeGeneratorOptions());
+                provider.GenerateCodeFromExpression(Expression, writer, new CodeGeneratorOptions());
                 Value = prefix + writer.ToString() + ")";
             }
         }
@@ -149,7 +149,7 @@ namespace PInvoke.Transform
 
             using (var writer = new StringWriter())
             {
-                provider.GenerateCodeFromExpression(_leftExpr, writer, new CodeGeneratorOptions());
+                provider.GenerateCodeFromExpression(Left, writer, new CodeGeneratorOptions());
                 expr += writer.ToString();
                 expr += ")";
             }
@@ -165,7 +165,7 @@ namespace PInvoke.Transform
 
             using (var writer = new StringWriter())
             {
-                provider.GenerateCodeFromExpression(_rightExpr, writer, new CodeGeneratorOptions());
+                provider.GenerateCodeFromExpression(Right, writer, new CodeGeneratorOptions());
                 expr += string.Format("({0})", writer.ToString());
             }
 
@@ -207,7 +207,7 @@ namespace PInvoke.Transform
             CodeDomProvider provider = GetProvider();
             using (var writer = new StringWriter())
             {
-                provider.GenerateCodeFromExpression(_expr, writer, new CodeGeneratorOptions());
+                provider.GenerateCodeFromExpression(Expression, writer, new CodeGeneratorOptions());
                 Value = "-" + writer.ToString();
             }
         }

--- a/PInvoke.Core/Transform/MarshalTransform.cs
+++ b/PInvoke.Core/Transform/MarshalTransform.cs
@@ -161,7 +161,7 @@ namespace PInvoke.Transform
 
         private void RunPluginUnionMembers(CodeTypeDeclaration ctd)
         {
-            if (TransformKindFlags.UnionMembers != (_kind & TransformKindFlags.UnionMembers))
+            if (TransformKindFlags.UnionMembers != (Kind & TransformKindFlags.UnionMembers))
             {
                 return;
             }
@@ -181,7 +181,7 @@ namespace PInvoke.Transform
 
         private void RunPluginEnumMembers(CodeTypeDeclaration ctd)
         {
-            if (TransformKindFlags.EnumMembers != (_kind & TransformKindFlags.EnumMembers))
+            if (TransformKindFlags.EnumMembers != (Kind & TransformKindFlags.EnumMembers))
             {
                 return;
             }
@@ -191,7 +191,7 @@ namespace PInvoke.Transform
 
         private void ProcessParameters(CodeMemberMethod codeProc)
         {
-            if (TransformKindFlags.Signature != (_kind & TransformKindFlags.Signature))
+            if (TransformKindFlags.Signature != (Kind & TransformKindFlags.Signature))
             {
                 return;
             }
@@ -207,7 +207,7 @@ namespace PInvoke.Transform
 
         private void ProcessReturnType(CodeMemberMethod codeMethod)
         {
-            if (TransformKindFlags.Signature != (_kind & TransformKindFlags.Signature))
+            if (TransformKindFlags.Signature != (Kind & TransformKindFlags.Signature))
             {
                 return;
             }
@@ -223,7 +223,7 @@ namespace PInvoke.Transform
 
         private void ProcessStructMembers(CodeTypeDeclaration ctd, TransformKindFlags kind)
         {
-            if (TransformKindFlags.StructMembers != (_kind & TransformKindFlags.StructMembers))
+            if (TransformKindFlags.StructMembers != (Kind & TransformKindFlags.StructMembers))
             {
                 return;
             }
@@ -239,7 +239,7 @@ namespace PInvoke.Transform
 
         private void ProcessWrapperMethods(CodeTypeDeclaration ctd, CodeMemberMethod codeMethod)
         {
-            if (TransformKindFlags.WrapperMethods != (_kind & TransformKindFlags.WrapperMethods))
+            if (TransformKindFlags.WrapperMethods != (Kind & TransformKindFlags.WrapperMethods))
             {
                 return;
             }

--- a/PInvoke.Core/Transform/MarshalTransform.cs
+++ b/PInvoke.Core/Transform/MarshalTransform.cs
@@ -37,7 +37,7 @@ namespace PInvoke.Transform
         public MarshalTransform(LanguageType lang, NativeSymbolBag bag, TransformKindFlags kind)
         {
             _trans = new CodeTransform(lang, bag);
-            _kind = kind;
+            Kind = kind;
 
             // Method Parameters
             _list.Add(new BooleanTypesTransformPlugin());

--- a/PInvoke.Core/Transform/SalAnalyzer.cs
+++ b/PInvoke.Core/Transform/SalAnalyzer.cs
@@ -56,7 +56,7 @@ namespace PInvoke.Transform
 
         public SalEntrySet(SalEntryListType type)
         {
-            _type = type;
+            Type = type;
         }
 
         public SalEntry FindEntry(SalEntryType type)

--- a/PInvoke.Test/CodeTransformTest.cs
+++ b/PInvoke.Test/CodeTransformTest.cs
@@ -45,10 +45,17 @@ namespace PInvoke.Test
         }
 
         [Fact()]
-        public void TryGenShift()
+        public void TryGenShift1()
         {
             VerifyExpression("1<<1", "(1) << (1)");
             VerifyExpression("1<< 4+2", "(1) << ((4 + 2))");
+        }
+
+        [Fact()]
+        public void TryGenShift2()
+        {
+            VerifyExpression("2>>1", "(2) >> (1)");
+            VerifyExpression("8>> 1+2", "(8) >> ((1 + 2))");
         }
 
         /// <summary>

--- a/PInvoke.Test/ExpressionEvaluatorTest.cs
+++ b/PInvoke.Test/ExpressionEvaluatorTest.cs
@@ -165,5 +165,30 @@ namespace PInvoke.Test
             AssertEval("1==1", 1);
             AssertEval("1==2", 0);
         }
+
+        [Fact()]
+        public void OpNotEquals1()
+        {
+            AssertEval("1!=2", 1);
+            AssertEval("1!=1", 0);
+            AssertEval("0!=0", 0);
+        }
+
+        [Fact()]
+        public void OpLessThan1()
+        {
+            AssertEval("1<2", 1);
+            AssertEval("2<1", 0);
+            AssertEval("1<1", 0);
+        }
+
+        [Fact()]
+        public void OpLessThanOrEquals1()
+        {
+            AssertEval("1<=2", 1);
+            AssertEval("2<=1", 0);
+            AssertEval("1<=1", 1);
+            AssertEval("0<=0", 1);
+        }
     }
 }

--- a/PInvoke.Test/NativeTypeBagTest.cs
+++ b/PInvoke.Test/NativeTypeBagTest.cs
@@ -63,6 +63,13 @@ namespace PInvoke.Test
         }
 
         [Fact()]
+        public void AddDefinedTypeTest4()
+        {
+            var bag = new NativeSymbolBag();
+            Assert.Throws<ArgumentNullException>(() => bag.AddDefinedType(null));
+        }
+
+        [Fact()]
         public void AddTypeDef1()
         {
             NativeSymbolBag bag = new NativeSymbolBag();
@@ -107,6 +114,13 @@ namespace PInvoke.Test
 
             bag.AddTypedef(td1);
             Assert.Throws<ArgumentException>(() => bag.AddTypedef(td2));
+        }
+
+        [Fact()]
+        public void AddTypeDef4()
+        {
+            var bag = new NativeSymbolBag();
+            Assert.Throws<ArgumentNullException>(() => bag.AddTypedef(null));
         }
 
         [Fact()]
@@ -289,6 +303,13 @@ namespace PInvoke.Test
             bag.AddProcedure(p1);
             bag.AddTypedef(new NativeTypeDef("foo", new NativeBuiltinType(BuiltinType.NativeFloat)));
             Assert.True(bag.TryResolveSymbolsAndValues());
+        }
+
+        [Fact()]
+        public void Proc7()
+        {
+            var bag = new NativeSymbolBag();
+            Assert.Throws<ArgumentNullException>(() => bag.AddProcedure(null));
         }
 
         [Fact()]


### PR DESCRIPTION
The attached set of patches add some tests and use property gets and sets instead of fields. I ran JetBrains dotCover before and after these patches and it shows that 127 additional statements are covered.