### PR TITLE
fix off-by one in #include parsing

### DIFF
--- a/PInvoke.Core/Parser/PreProcessor.cs
+++ b/PInvoke.Core/Parser/PreProcessor.cs
@@ -638,24 +638,24 @@ namespace PInvoke.Parser
             List<Token> list = new List<Token>(line.GetValidTokens());
 
             // Get rid of the #include
-            ThrowIfFalse(list[1].TokenType == TokenType.PoundInclude);
+            ThrowIfFalse(list[0].TokenType == TokenType.PoundInclude);
             list.RemoveAt(0);
 
             string name = null;
-            if (list[1].TokenType == TokenType.OpLessThan)
+            if (list[0].TokenType == TokenType.OpLessThan)
             {
                 name = string.Empty;
                 list.RemoveAt(0);
-                while (list[1].TokenType != TokenType.OpGreaterThan)
+                while (list[0].TokenType != TokenType.OpGreaterThan)
                 {
-                    name += list[1].Value;
+                    name += list[0].Value;
                     list.RemoveAt(0);
                 }
                 list.RemoveAt(0);
             }
-            else if (list[1].IsQuotedString)
+            else if (list[0].IsQuotedString)
             {
-                name = TokenHelper.ConvertToString(list[1]);
+                name = TokenHelper.ConvertToString(list[0]);
             }
             else
             {

--- a/PInvoke.Test/NativePreProcessorTest.cs
+++ b/PInvoke.Test/NativePreProcessorTest.cs
@@ -96,6 +96,17 @@ namespace PInvoke.Test
         }
 
         [Fact()]
+        public void PoundInclude1()
+        {
+            string before = @"#include ""non_existent_file.h""";
+            string after = "";
+            var opts = new PreProcessorOptions() { FollowIncludes = true };
+            var map = VerifyImpl(opts, before, after);
+
+            Assert.True(map.Count == 0); // include not found
+        }
+
+        [Fact()]
         public void Conditional1()
         {
             string before = "#define foo bar" + PortConstants.NewLine + "#if foo" + PortConstants.NewLine + "hello" + PortConstants.NewLine + "#endif";


### PR DESCRIPTION
I compared to the original VB sources, and it looks like 0 became 1 when it was translated to C#, but the other methods are OK. Without this change the codepath throws.

@jaredpar 